### PR TITLE
Fix logout links in admin and client navbars

### DIFF
--- a/views/admin/includes/navbar.php
+++ b/views/admin/includes/navbar.php
@@ -21,7 +21,7 @@
                 </ul>
                 <div class="ms-lg-4 mt-3 mt-lg-0 d-flex align-items-center gap-3">
                     <span class="badge-user"><i class="bi bi-person-circle me-2"></i>Administrador</span>
-                    <a class="btn btn-outline-light rounded-pill px-4" href="/camila-textil/controllers/auth/logout.php">Cerrar sesión</a>
+                    <a class="btn btn-outline-light rounded-pill px-4" href="<?= BASE_URL ?>/controllers/logout.php">Cerrar sesión</a>
                 </div>
             </div>
         </div>

--- a/views/cliente/includes/navbar.php
+++ b/views/cliente/includes/navbar.php
@@ -17,7 +17,7 @@
                     <li class="nav-item"><a class="nav-link" href="perfil.php"><i class="bi bi-person me-2"></i>Mi perfil</a></li>
                 </ul>
                 <div class="ms-lg-4 mt-3 mt-lg-0">
-                    <a class="btn btn-outline-light rounded-pill px-4" href="/camila-textil/controllers/auth/logout.php">Cerrar sesión</a>
+                    <a class="btn btn-outline-light rounded-pill px-4" href="<?= BASE_URL ?>/controllers/logout.php">Cerrar sesión</a>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- update admin and client navbar logout buttons to point to the shared logout controller using BASE_URL

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e6f97139e08325beb0e755ef4bfcb1