### PR TITLE
Ensure cliente views require authenticated session

### DIFF
--- a/views/cliente/dashboard.php
+++ b/views/cliente/dashboard.php
@@ -1,4 +1,5 @@
 <?php
+require_once __DIR__ . '/includes/init.php';
 require_once __DIR__ . '/../../models/pedido.php';
 require_once __DIR__ . '/../../models/producto.php';
 

--- a/views/cliente/includes/init.php
+++ b/views/cliente/includes/init.php
@@ -1,0 +1,19 @@
+<?php
+// views/cliente/includes/init.php
+if (session_status() !== PHP_SESSION_ACTIVE) {
+    session_start();
+}
+
+require_once __DIR__ . '/../../../config/app.php';
+
+if (!isset($_SESSION['usuario'])) {
+    header('Location: ' . BASE_URL . '/views/public/login.php');
+    exit;
+}
+
+$clienteActual = $_SESSION['usuario'];
+
+if (($clienteActual['rol'] ?? '') !== 'cliente') {
+    header('Location: ' . BASE_URL . '/index.php');
+    exit;
+}

--- a/views/cliente/pedidos.php
+++ b/views/cliente/pedidos.php
@@ -1,4 +1,7 @@
-<!-- views/cliente/pedidos.php -->
+<?php
+require_once __DIR__ . '/includes/init.php';
+// views/cliente/pedidos.php
+?>
 <?php include('includes/header.php'); ?>
 <?php include('includes/navbar.php'); ?>
 

--- a/views/cliente/perfil.php
+++ b/views/cliente/perfil.php
@@ -1,4 +1,7 @@
-<!-- views/cliente/perfil.php -->
+<?php
+require_once __DIR__ . '/includes/init.php';
+// views/cliente/perfil.php
+?>
 <?php include('includes/header.php'); ?>
 <?php include('includes/navbar.php'); ?>
 

--- a/views/cliente/productos.php
+++ b/views/cliente/productos.php
@@ -1,4 +1,7 @@
-<!-- views/cliente/productos.php -->
+<?php
+require_once __DIR__ . '/includes/init.php';
+// views/cliente/productos.php
+?>
 <?php include('includes/header.php'); ?>
 <?php include('includes/navbar.php'); ?>
 


### PR DESCRIPTION
## Summary
- add a shared initialization include for cliente views to bootstrap the session and current user
- enforce that only authenticated clientes can access the dashboard, pedidos, productos, and perfil views

## Testing
- php -l views/cliente/includes/init.php
- php -l views/cliente/dashboard.php
- php -l views/cliente/pedidos.php
- php -l views/cliente/productos.php
- php -l views/cliente/perfil.php

------
https://chatgpt.com/codex/tasks/task_e_68e6f9795b9c83258f1daf56a2e30f8d