### PR TITLE
Protege vistas administrativas con verificación de sesión

### DIFF
--- a/views/admin/includes/header.php
+++ b/views/admin/includes/header.php
@@ -1,3 +1,15 @@
+<?php
+if (session_status() === PHP_SESSION_NONE) {
+    session_start();
+}
+
+require_once __DIR__ . '/../../../config/app.php';
+
+if (empty($_SESSION['usuario']) || ($_SESSION['rol'] ?? null) !== 'administrador') {
+    header('Location: ' . BASE_URL . '/views/public/login.php');
+    exit;
+}
+?>
 <!-- views/admin/includes/header.php -->
 <!DOCTYPE html>
 <html lang="es">


### PR DESCRIPTION
## Summary
- inicia la sesión en el encabezado compartido del panel administrativo
- valida que el usuario autenticado tenga el rol de administrador antes de cargar cualquier vista
- redirige a la página de inicio de sesión pública si no se cumplen las credenciales necesarias

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e6f97fba908325acd2df306cd1f037