### PR TITLE
Fix header asset URLs to respect BASE_URL

### DIFF
--- a/views/admin/includes/header.php
+++ b/views/admin/includes/header.php
@@ -1,3 +1,6 @@
+<?php
+require_once __DIR__ . '/../../../config/app.php';
+?>
 <!-- views/admin/includes/header.php -->
 <!DOCTYPE html>
 <html lang="es">
@@ -10,6 +13,6 @@
     <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700&display=swap" rel="stylesheet">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css" rel="stylesheet">
-    <link rel="stylesheet" href="/camila-textil/assets/css/estilos-admin.css">
+    <link rel="stylesheet" href="<?= BASE_URL ?>/assets/css/estilos-admin.css">
 </head>
 <body class="admin-layout">

--- a/views/cliente/includes/header.php
+++ b/views/cliente/includes/header.php
@@ -1,3 +1,6 @@
+<?php
+require_once __DIR__ . '/../../../config/app.php';
+?>
 <!-- views/cliente/includes/header.php -->
 <!DOCTYPE html>
 <html lang="es">
@@ -10,6 +13,6 @@
     <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700&display=swap" rel="stylesheet">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css" rel="stylesheet">
-    <link rel="stylesheet" href="/camila-textil/assets/css/estilos-cliente.css">
+    <link rel="stylesheet" href="<?= BASE_URL ?>/assets/css/estilos-cliente.css">
 </head>
 <body class="client-layout">

--- a/views/public/includes/header.php
+++ b/views/public/includes/header.php
@@ -16,6 +16,6 @@ require_once __DIR__ . '/../../../config/app.php';
     <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700&display=swap" rel="stylesheet">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css" rel="stylesheet">
-    <link rel="stylesheet" href="/camila-textil/assets/css/estilos-publico.css">
+    <link rel="stylesheet" href="<?= BASE_URL ?>/assets/css/estilos-publico.css">
 </head>
 <body class="public-layout">


### PR DESCRIPTION
## Summary
- replace hardcoded stylesheet URLs in the public, admin, and client headers with paths built from BASE_URL
- load the application configuration in admin and client headers so BASE_URL is available everywhere

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e6f985c1888325a36b1c5e46b95ce0