### PR TITLE
Add realistic seed data for SQL tables

### DIFF
--- a/database/tablas.sql
+++ b/database/tablas.sql
@@ -71,5 +71,54 @@ CREATE TABLE sucursales (
     fecha_creacion TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 
--- Agregar datos iniciales de ejemplo (puedes agregar más si es necesario)
-INSERT INTO usuarios (nombre, email, clave, rol) VALUES ('Administrador', 'admin@camilatextil.com', 'admin123', 'administrador');
+-- Datos de ejemplo realistas
+
+-- Usuarios (un administrador y dos clientes)
+INSERT INTO usuarios (nombre, email, clave, rol) VALUES
+('Camila Rivas', 'admin@camilatextiles.com', '$2y$12$IZg2ygBFt728hSrSVFfVEeyllnPpCrPHKle5pUs9mw5fgfOFTJ3x.', 'administrador'),
+('Lucía Fernández', 'lucia.fernandez@example.com', '$2y$12$COytam4/33Irk1uUJ8UCLOnvtZHLxdWOmEa0RYgI7wd3e7j0TmsUW', 'cliente'),
+('Marcos Delgado', 'marcos.delgado@example.com', '$2y$12$HhptmQQo1zLJDjUJeE2HVuzNh4h19ngGZE1ftgZ8Rd62X.qxq5XSy', 'cliente');
+
+-- Productos textiles con imágenes externas para el catálogo
+INSERT INTO productos (nombre, descripcion, precio, imagen, visible) VALUES
+('Poncho Andino de Alpaca', 'Poncho tejido a mano con fibras de alpaca de la sierra peruana. Ideal para climas fríos y noches de fogata.', 249.90, 'https://images.unsplash.com/photo-1503341455253-b2e723bb3dbb?auto=format&fit=crop&w=900&q=80', TRUE),
+('Manta Decorativa Cusqueña', 'Manta multicolor inspirada en patrones tradicionales cusqueños, perfecta para sofás o camas.', 189.50, 'https://images.unsplash.com/photo-1512436991641-6745cdb1723f?auto=format&fit=crop&w=900&q=80', TRUE),
+('Bolso de Yute Eco Chic', 'Bolso tote de yute reforzado con asas de cuero vegano, ideal para compras sostenibles.', 89.90, 'https://images.unsplash.com/photo-1542291026-7eec264c27ff?auto=format&fit=crop&w=900&q=80', TRUE),
+('Camisa de Lino Premium', 'Camisa de lino orgánico con botones de coco, fresca y elegante para eventos de verano.', 139.00, 'https://images.unsplash.com/photo-1521572267360-ee0c2909d518?auto=format&fit=crop&w=900&q=80', TRUE),
+('Alfombra Artesanal Arequipeña', 'Alfombra tejida en telar artesanal con lana merino, tonos tierra para ambientes cálidos.', 329.00, 'https://images.unsplash.com/photo-1505691938895-1758d7feb511?auto=format&fit=crop&w=900&q=80', TRUE),
+('Camino de Mesa Bordado', 'Camino de mesa bordado a mano con flores andinas, ideal para resaltar mesas de comedor.', 74.50, 'https://images.unsplash.com/photo-1503342217505-b0a15ec3261c?auto=format&fit=crop&w=900&q=80', TRUE);
+
+-- Inventario disponible por producto
+INSERT INTO inventarios (id_producto, cantidad) VALUES
+(1, 35),
+(2, 28),
+(3, 60),
+(4, 42),
+(5, 18),
+(6, 55);
+
+-- Pedidos registrados por los clientes
+INSERT INTO pedidos (id_usuario, id_producto, cantidad, estado) VALUES
+(2, 1, 1, 'confirmado'),
+(2, 3, 2, 'pendiente'),
+(3, 2, 1, 'completado'),
+(3, 6, 3, 'pendiente');
+
+-- Comentarios visibles en el detalle de productos
+INSERT INTO comentarios (id_producto, id_usuario, comentario) VALUES
+(1, 2, 'La textura del poncho es suave y abriga muchísimo. Llegó antes de lo esperado.'),
+(3, 2, 'Muy resistente y con un diseño hermoso. Lo uso para todas mis compras.'),
+(2, 3, 'Los colores son idénticos a las fotos y le dan vida a mi sala.'),
+(6, 3, 'Ideal para reuniones familiares, todos preguntaron dónde lo compré.');
+
+-- Equipo de la tienda
+INSERT INTO empleados (nombre, puesto, salario) VALUES
+('Valeria Nuñez', 'Gerente de tienda', 4200.00),
+('Javier Morales', 'Especialista en logística', 3200.00),
+('Anaïs Campos', 'Diseñadora textil', 3800.00);
+
+-- Sucursales activas de la marca
+INSERT INTO sucursales (nombre, direccion, telefono, horario_apertura) VALUES
+('Showroom Miraflores', 'Av. Larco 1021, Miraflores, Lima', '+51 1 456 7890', 'Lunes a sábado de 10:00 a 21:00'),
+('Taller Artesanal Arequipa', 'Jr. Misti 548, Arequipa', '+51 54 321 654', 'Lunes a viernes de 09:00 a 18:00'),
+('Boutique Cusco', 'Calle Triunfo 347, Cusco', '+51 84 765 432', 'Todos los días de 10:00 a 20:00');


### PR DESCRIPTION
## Summary
- add sample records for usuarios, productos, inventarios, pedidos, comentarios, empleados y sucursales
- include product entries with external image URLs to populate catalog data

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e6eb0cb1388325aafb64c10f054f48