### PR TITLE
Homogenize textile catalog details and schema

### DIFF
--- a/controllers/productos.php
+++ b/controllers/productos.php
@@ -13,13 +13,16 @@ class ProductosController {
 
     public function agregarProducto() {
         if ($_SERVER['REQUEST_METHOD'] == 'POST') {
-            $nombre = $_POST['nombre'];
-            $descripcion = $_POST['descripcion'];
-            $precio = $_POST['precio'];
-            $imagen = $_POST['imagen'];  // Usaremos una URL externa para la imagen
+            $nombre = trim($_POST['nombre']);
+            $descripcion = trim($_POST['descripcion']);
+            $color = trim($_POST['color']);
+            $unidadVenta = $_POST['unidad_venta'] ?? 'metro';
+            $unidadVenta = in_array($unidadVenta, ['metro', 'rollo'], true) ? $unidadVenta : 'metro';
+            $precio = (float) $_POST['precio'];
+            $imagen = trim($_POST['imagen']);  // Usaremos una URL externa para la imagen
 
             $productoModel = new Producto();
-            $productoModel->agregarProducto($nombre, $descripcion, $precio, $imagen);
+            $productoModel->agregarProducto($nombre, $descripcion, $color, $unidadVenta, $precio, $imagen);
             header('Location: /admin/productos');
         }
         include('views/admin/agregar_producto.php');
@@ -30,12 +33,15 @@ class ProductosController {
         $producto = $productoModel->obtenerProductoPorId($id);
 
         if ($_SERVER['REQUEST_METHOD'] == 'POST') {
-            $nombre = $_POST['nombre'];
-            $descripcion = $_POST['descripcion'];
-            $precio = $_POST['precio'];
-            $imagen = $_POST['imagen'];  // Usaremos una URL externa para la imagen
+            $nombre = trim($_POST['nombre']);
+            $descripcion = trim($_POST['descripcion']);
+            $color = trim($_POST['color']);
+            $unidadVenta = $_POST['unidad_venta'] ?? 'metro';
+            $unidadVenta = in_array($unidadVenta, ['metro', 'rollo'], true) ? $unidadVenta : 'metro';
+            $precio = (float) $_POST['precio'];
+            $imagen = trim($_POST['imagen']);  // Usaremos una URL externa para la imagen
 
-            $productoModel->editarProducto($id, $nombre, $descripcion, $precio, $imagen);
+            $productoModel->editarProducto($id, $nombre, $descripcion, $color, $unidadVenta, $precio, $imagen);
             header('Location: /admin/productos');
         }
 

--- a/database/migracoines/datos_prueba.sql
+++ b/database/migracoines/datos_prueba.sql
@@ -8,25 +8,25 @@ INSERT INTO usuarios (nombre, email, clave, rol) VALUES
 ('Pedro Martínez', 'pedro.martinez@outlook.com', 'cliente789', 'cliente');
 
 -- Insertar productos (productos disponibles para la venta)
-INSERT INTO productos (nombre, descripcion, precio, imagen, visible) VALUES
-('Tela Algodón', 'Tela de algodón de alta calidad para confección de ropa.', 25.50, 'https://via.placeholder.com/150', TRUE),
-('Tela Seda', 'Tela de seda ideal para vestidos de lujo.', 75.00, 'https://via.placeholder.com/150', TRUE),
-('Tela Lana', 'Tela gruesa de lana perfecta para chaquetas y abrigos.', 50.00, 'https://via.placeholder.com/150', TRUE),
-('Tela Lino', 'Tela de lino, fresca y cómoda para ropa veraniega.', 40.00, 'https://via.placeholder.com/150', TRUE);
+INSERT INTO productos (nombre, descripcion, color, unidad_venta, precio, imagen, visible) VALUES
+('Tela Algodón Peinado', 'Tejido plano 100% algodón, ideal para camisería y ropa casual.', 'Marfil', 'metro', 48.50, 'https://via.placeholder.com/150', TRUE),
+('Tela Seda Natural', 'Satín de seda con caída fluida para vestidos de alta costura.', 'Perla', 'metro', 182.90, 'https://via.placeholder.com/150', TRUE),
+('Tela Lana Merino', 'Paño de lana merino cardada, óptimo para abrigos y sacos ejecutivos.', 'Gris Oxford', 'rollo', 1240.00, 'https://via.placeholder.com/150', TRUE),
+('Tela Lino Premium', 'Lino europeo de tacto fresco para colecciones primavera/verano.', 'Arena', 'metro', 66.75, 'https://via.placeholder.com/150', TRUE);
 
 -- Insertar inventarios
 INSERT INTO inventarios (id_producto, cantidad) VALUES
-(1, 100),
-(2, 50),
-(3, 80),
-(4, 150);
+(1, 320.00),
+(2, 180.00),
+(3, 24.00),
+(4, 410.00);
 
 -- Insertar pedidos (pedidos realizados por los clientes)
-INSERT INTO pedidos (id_usuario, id_producto, cantidad, estado) VALUES
-(2, 1, 3, 'pendiente'),
-(3, 2, 2, 'confirmado'),
-(4, 3, 5, 'completado'),
-(2, 4, 10, 'pendiente');
+INSERT INTO pedidos (id_usuario, id_producto, cantidad, unidad_venta, estado) VALUES
+(2, 1, 45.00, 'metro', 'pendiente'),
+(3, 2, 18.50, 'metro', 'confirmado'),
+(4, 3, 3.00, 'rollo', 'completado'),
+(2, 4, 120.00, 'metro', 'pendiente');
 
 -- Insertar comentarios (comentarios realizados por los clientes sobre productos)
 INSERT INTO comentarios (id_producto, id_usuario, comentario) VALUES

--- a/database/tablas.sql
+++ b/database/tablas.sql
@@ -15,7 +15,9 @@ CREATE TABLE productos (
     id INT AUTO_INCREMENT PRIMARY KEY,
     nombre VARCHAR(255) NOT NULL,
     descripcion TEXT,
-    precio DECIMAL(10, 2) NOT NULL,
+    color VARCHAR(120) NOT NULL, -- Paleta cromática que identifica la tela
+    unidad_venta ENUM('metro', 'rollo') NOT NULL DEFAULT 'metro', -- Unidad comercial principal
+    precio DECIMAL(10, 2) NOT NULL, -- Precio expresado en bolivianos (Bs)
     imagen VARCHAR(255) NOT NULL,  -- Usamos URL externa para la imagen
     visible BOOLEAN DEFAULT TRUE,  -- Define si el producto es visible en el catálogo
     fecha_creacion TIMESTAMP DEFAULT CURRENT_TIMESTAMP
@@ -25,7 +27,7 @@ CREATE TABLE productos (
 CREATE TABLE inventarios (
     id INT AUTO_INCREMENT PRIMARY KEY,
     id_producto INT NOT NULL,
-    cantidad INT NOT NULL,
+    cantidad DECIMAL(10, 2) NOT NULL, -- Control de stock expresado en la misma unidad de venta del producto
     FOREIGN KEY (id_producto) REFERENCES productos(id) ON DELETE CASCADE
 );
 
@@ -34,7 +36,8 @@ CREATE TABLE pedidos (
     id INT AUTO_INCREMENT PRIMARY KEY,
     id_usuario INT NOT NULL,
     id_producto INT NOT NULL,
-    cantidad INT NOT NULL,
+    cantidad DECIMAL(10, 2) NOT NULL,
+    unidad_venta ENUM('metro', 'rollo') NOT NULL DEFAULT 'metro', -- Registra si el pedido fue reservado por metro lineal o rollo
     estado ENUM('pendiente', 'confirmado', 'completado', 'cancelado') NOT NULL DEFAULT 'pendiente',
     fecha_creacion TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     FOREIGN KEY (id_usuario) REFERENCES usuarios(id),

--- a/models/inventario.php
+++ b/models/inventario.php
@@ -9,7 +9,7 @@ class Inventario {
     public function obtenerInventario() {
         global $pdo;
 
-        $stmt = $pdo->prepare("SELECT p.nombre, i.cantidad FROM inventarios i INNER JOIN productos p ON i.id_producto = p.id");
+        $stmt = $pdo->prepare("SELECT i.id_producto, p.nombre, p.unidad_venta, i.cantidad FROM inventarios i INNER JOIN productos p ON i.id_producto = p.id");
         $stmt->execute();
         return $stmt->fetchAll(PDO::FETCH_ASSOC);
     }
@@ -19,7 +19,7 @@ class Inventario {
         global $pdo;
 
         $stmt = $pdo->prepare("INSERT INTO inventarios (id_producto, cantidad) VALUES (:id_producto, :cantidad)");
-        return $stmt->execute(['id_producto' => $idProducto, 'cantidad' => $cantidad]);
+        return $stmt->execute(['id_producto' => $idProducto, 'cantidad' => (float) $cantidad]);
     }
 
     // Método para eliminar un producto del inventario

--- a/models/producto.php
+++ b/models/producto.php
@@ -24,19 +24,34 @@ class Producto {
     }
 
     // Método para agregar un nuevo producto
-    public function agregarProducto($nombre, $descripcion, $precio, $imagen) {
+    public function agregarProducto($nombre, $descripcion, $color, $unidadVenta, $precio, $imagen) {
         global $pdo;
 
-        $stmt = $pdo->prepare("INSERT INTO productos (nombre, descripcion, precio, imagen) VALUES (:nombre, :descripcion, :precio, :imagen)");
-        return $stmt->execute(['nombre' => $nombre, 'descripcion' => $descripcion, 'precio' => $precio, 'imagen' => $imagen]);
+        $stmt = $pdo->prepare("INSERT INTO productos (nombre, descripcion, color, unidad_venta, precio, imagen) VALUES (:nombre, :descripcion, :color, :unidad_venta, :precio, :imagen)");
+        return $stmt->execute([
+            'nombre' => $nombre,
+            'descripcion' => $descripcion,
+            'color' => $color,
+            'unidad_venta' => $unidadVenta,
+            'precio' => $precio,
+            'imagen' => $imagen
+        ]);
     }
 
     // Método para editar un producto
-    public function editarProducto($id, $nombre, $descripcion, $precio, $imagen) {
+    public function editarProducto($id, $nombre, $descripcion, $color, $unidadVenta, $precio, $imagen) {
         global $pdo;
 
-        $stmt = $pdo->prepare("UPDATE productos SET nombre = :nombre, descripcion = :descripcion, precio = :precio, imagen = :imagen WHERE id = :id");
-        return $stmt->execute(['id' => $id, 'nombre' => $nombre, 'descripcion' => $descripcion, 'precio' => $precio, 'imagen' => $imagen]);
+        $stmt = $pdo->prepare("UPDATE productos SET nombre = :nombre, descripcion = :descripcion, color = :color, unidad_venta = :unidad_venta, precio = :precio, imagen = :imagen WHERE id = :id");
+        return $stmt->execute([
+            'id' => $id,
+            'nombre' => $nombre,
+            'descripcion' => $descripcion,
+            'color' => $color,
+            'unidad_venta' => $unidadVenta,
+            'precio' => $precio,
+            'imagen' => $imagen
+        ]);
     }
 
     // Método para eliminar un producto

--- a/views/admin/agregar_producto.php
+++ b/views/admin/agregar_producto.php
@@ -21,8 +21,19 @@
                             <textarea class="form-control" id="descripcion" name="descripcion" rows="4" required></textarea>
                         </div>
                         <div class="col-md-6">
-                            <label for="precio" class="form-label">Precio (USD)</label>
-                            <input type="number" class="form-control" id="precio" name="precio" step="0.01" required>
+                            <label for="color" class="form-label">Color predominante</label>
+                            <input type="text" class="form-control" id="color" name="color" placeholder="Ej. Azul petróleo" required>
+                        </div>
+                        <div class="col-md-6">
+                            <label for="unidad_venta" class="form-label">Unidad de venta</label>
+                            <select class="form-select" id="unidad_venta" name="unidad_venta" required>
+                                <option value="metro">Metro lineal</option>
+                                <option value="rollo">Rollo completo</option>
+                            </select>
+                        </div>
+                        <div class="col-md-6">
+                            <label for="precio" class="form-label">Precio (Bs)</label>
+                            <input type="number" class="form-control" id="precio" name="precio" step="0.01" min="0" required>
                         </div>
                         <div class="col-md-6">
                             <label for="imagen" class="form-label">URL de imagen</label>

--- a/views/admin/editar_producto.php
+++ b/views/admin/editar_producto.php
@@ -12,22 +12,33 @@
             <div class="col-12 col-xl-8">
                 <div class="form-shell">
                     <form action="productos.php" method="POST" class="row g-4">
-                        <input type="hidden" name="id" value="<?= $producto['id'] ?>">
+                        <input type="hidden" name="id" value="<?= (int) $producto['id'] ?>">
                         <div class="col-12">
                             <label for="nombre" class="form-label">Nombre del producto</label>
-                            <input type="text" class="form-control" id="nombre" name="nombre" value="<?= $producto['nombre'] ?>" required>
+                            <input type="text" class="form-control" id="nombre" name="nombre" value="<?= htmlspecialchars($producto['nombre'], ENT_QUOTES, 'UTF-8') ?>" required>
                         </div>
                         <div class="col-12">
                             <label for="descripcion" class="form-label">Descripción</label>
-                            <textarea class="form-control" id="descripcion" name="descripcion" rows="4" required><?= $producto['descripcion'] ?></textarea>
+                            <textarea class="form-control" id="descripcion" name="descripcion" rows="4" required><?= htmlspecialchars($producto['descripcion'], ENT_QUOTES, 'UTF-8') ?></textarea>
                         </div>
                         <div class="col-md-6">
-                            <label for="precio" class="form-label">Precio (USD)</label>
-                            <input type="number" class="form-control" id="precio" name="precio" step="0.01" value="<?= $producto['precio'] ?>" required>
+                            <label for="color" class="form-label">Color predominante</label>
+                            <input type="text" class="form-control" id="color" name="color" value="<?= htmlspecialchars($producto['color'], ENT_QUOTES, 'UTF-8') ?>" required>
+                        </div>
+                        <div class="col-md-6">
+                            <label for="unidad_venta" class="form-label">Unidad de venta</label>
+                            <select class="form-select" id="unidad_venta" name="unidad_venta" required>
+                                <option value="metro" <?= $producto['unidad_venta'] === 'metro' ? 'selected' : '' ?>>Metro lineal</option>
+                                <option value="rollo" <?= $producto['unidad_venta'] === 'rollo' ? 'selected' : '' ?>>Rollo completo</option>
+                            </select>
+                        </div>
+                        <div class="col-md-6">
+                            <label for="precio" class="form-label">Precio (Bs)</label>
+                            <input type="number" class="form-control" id="precio" name="precio" step="0.01" min="0" value="<?= htmlspecialchars($producto['precio'], ENT_QUOTES, 'UTF-8') ?>" required>
                         </div>
                         <div class="col-md-6">
                             <label for="imagen" class="form-label">URL de imagen</label>
-                            <input type="url" class="form-control" id="imagen" name="imagen" value="<?= $producto['imagen'] ?>" required>
+                            <input type="url" class="form-control" id="imagen" name="imagen" value="<?= htmlspecialchars($producto['imagen'], ENT_QUOTES, 'UTF-8') ?>" required>
                         </div>
                         <div class="col-12 text-end">
                             <a href="productos.php" class="btn btn-outline-primary me-2">Volver</a>

--- a/views/admin/inventario.php
+++ b/views/admin/inventario.php
@@ -15,14 +15,17 @@
                         <tr>
                             <th>Producto</th>
                             <th>Cantidad disponible</th>
+                            <th>Unidad de venta</th>
                             <th class="text-end">Acciones</th>
                         </tr>
                     </thead>
                     <tbody>
                         <?php foreach ($inventario as $item): ?>
+                            <?php $nombreProducto = htmlspecialchars($item['nombre'], ENT_QUOTES, 'UTF-8'); ?>
                             <tr>
-                                <td><?= $item['nombre'] ?></td>
-                                <td><?= $item['cantidad'] ?></td>
+                                <td><?= $nombreProducto ?></td>
+                                <td><?= number_format($item['cantidad'], 2, ',', '.') ?></td>
+                                <td><?= $item['unidad_venta'] === 'rollo' ? 'Rollo' : 'Metro' ?></td>
                                 <td class="text-end text-nowrap">
                                     <a href="agregar_inventario.php?id=<?= $item['id_producto'] ?>" class="btn btn-info btn-sm me-2">Ajustar stock</a>
                                     <a href="eliminar_inventario.php?id=<?= $item['id_producto'] ?>" class="btn btn-danger btn-sm">Reducir</a>

--- a/views/admin/pedidos.php
+++ b/views/admin/pedidos.php
@@ -17,18 +17,26 @@
                             <th>Cliente</th>
                             <th>Producto</th>
                             <th>Cantidad</th>
+                            <th>Unidad</th>
                             <th>Estado</th>
                             <th class="text-end">Acciones</th>
                         </tr>
                     </thead>
                     <tbody>
                         <?php foreach ($pedidos as $pedido): ?>
+                            <?php
+                                $cliente = htmlspecialchars($pedido['cliente'] ?? '', ENT_QUOTES, 'UTF-8');
+                                $producto = htmlspecialchars($pedido['producto'] ?? '', ENT_QUOTES, 'UTF-8');
+                                $estado = htmlspecialchars($pedido['estado'] ?? '', ENT_QUOTES, 'UTF-8');
+                                $unidad = isset($pedido['unidad_venta']) && $pedido['unidad_venta'] === 'rollo' ? 'Rollo' : 'Metro';
+                            ?>
                             <tr>
                                 <td><?= $pedido['id'] ?></td>
-                                <td><?= $pedido['cliente'] ?></td>
-                                <td><?= $pedido['producto'] ?></td>
-                                <td><?= $pedido['cantidad'] ?></td>
-                                <td><?= $pedido['estado'] ?></td>
+                                <td><?= $cliente ?></td>
+                                <td><?= $producto ?></td>
+                                <td><?= number_format($pedido['cantidad'], 2, ',', '.') ?></td>
+                                <td><?= $unidad ?></td>
+                                <td><?= $estado ?></td>
                                 <td class="text-end text-nowrap">
                                     <a href="confirmar_pedido.php?id=<?= $pedido['id'] ?>" class="btn btn-success btn-sm me-2">Confirmar</a>
                                     <a href="cancelar_pedido.php?id=<?= $pedido['id'] ?>" class="btn btn-danger btn-sm">Cancelar</a>

--- a/views/admin/productos.php
+++ b/views/admin/productos.php
@@ -21,17 +21,27 @@
                             <th>ID</th>
                             <th>Nombre</th>
                             <th>Descripción</th>
-                            <th>Precio</th>
+                            <th>Color</th>
+                            <th>Unidad de venta</th>
+                            <th>Precio (Bs)</th>
                             <th>Acciones</th>
                         </tr>
                     </thead>
                     <tbody>
                         <?php foreach ($productos as $producto): ?>
+                            <?php
+                                $nombreProducto = htmlspecialchars($producto['nombre'], ENT_QUOTES, 'UTF-8');
+                                $descripcionProducto = htmlspecialchars($producto['descripcion'], ENT_QUOTES, 'UTF-8');
+                                $colorProducto = htmlspecialchars($producto['color'], ENT_QUOTES, 'UTF-8');
+                                $unidadVenta = $producto['unidad_venta'] === 'rollo' ? 'Rollo completo' : 'Metro lineal';
+                            ?>
                             <tr>
                                 <td><?= $producto['id'] ?></td>
-                                <td><?= $producto['nombre'] ?></td>
-                                <td><?= $producto['descripcion'] ?></td>
-                                <td><?= '$' . number_format($producto['precio'], 2) ?></td>
+                                <td><?= $nombreProducto ?></td>
+                                <td><?= $descripcionProducto ?></td>
+                                <td><?= $colorProducto ?></td>
+                                <td><?= $unidadVenta ?></td>
+                                <td><?= 'Bs ' . number_format($producto['precio'], 2, ',', '.') ?></td>
                                 <td class="text-nowrap">
                                     <a href="editar_producto.php?id=<?= $producto['id'] ?>" class="btn btn-warning btn-sm">Editar</a>
                                     <a href="eliminar_producto.php?id=<?= $producto['id'] ?>" class="btn btn-danger btn-sm">Eliminar</a>

--- a/views/cliente/pedidos.php
+++ b/views/cliente/pedidos.php
@@ -18,17 +18,24 @@
                                 <th>ID Pedido</th>
                                 <th>Producto</th>
                                 <th>Cantidad</th>
+                                <th>Unidad</th>
                                 <th>Estado</th>
                                 <th class="text-end">Acciones</th>
                             </tr>
                         </thead>
                         <tbody>
                             <?php foreach ($pedidosActivos as $pedido): ?>
+                                <?php
+                                    $producto = htmlspecialchars($pedido['producto'] ?? '', ENT_QUOTES, 'UTF-8');
+                                    $estado = htmlspecialchars($pedido['estado'] ?? '', ENT_QUOTES, 'UTF-8');
+                                    $unidad = isset($pedido['unidad_venta']) && $pedido['unidad_venta'] === 'rollo' ? 'Rollo' : 'Metro';
+                                ?>
                                 <tr>
                                     <td><?= $pedido['id'] ?></td>
-                                    <td><?= $pedido['producto'] ?></td>
-                                    <td><?= $pedido['cantidad'] ?></td>
-                                    <td><?= $pedido['estado'] ?></td>
+                                    <td><?= $producto ?></td>
+                                    <td><?= number_format($pedido['cantidad'], 2, ',', '.') ?></td>
+                                    <td><?= $unidad ?></td>
+                                    <td><?= $estado ?></td>
                                     <td class="text-end text-nowrap">
                                         <a href="ver_detalles_pedido.php?id=<?= $pedido['id'] ?>" class="btn btn-info btn-sm">Ver detalles</a>
                                     </td>
@@ -49,18 +56,26 @@
                                 <th>ID Pedido</th>
                                 <th>Producto</th>
                                 <th>Cantidad</th>
+                                <th>Unidad</th>
                                 <th>Estado</th>
                                 <th>Fecha</th>
                             </tr>
                         </thead>
                         <tbody>
                             <?php foreach ($pedidosHistoricos as $pedido): ?>
+                                <?php
+                                    $producto = htmlspecialchars($pedido['producto'] ?? '', ENT_QUOTES, 'UTF-8');
+                                    $estado = htmlspecialchars($pedido['estado'] ?? '', ENT_QUOTES, 'UTF-8');
+                                    $fecha = htmlspecialchars($pedido['fecha'] ?? '', ENT_QUOTES, 'UTF-8');
+                                    $unidad = isset($pedido['unidad_venta']) && $pedido['unidad_venta'] === 'rollo' ? 'Rollo' : 'Metro';
+                                ?>
                                 <tr>
                                     <td><?= $pedido['id'] ?></td>
-                                    <td><?= $pedido['producto'] ?></td>
-                                    <td><?= $pedido['cantidad'] ?></td>
-                                    <td><?= $pedido['estado'] ?></td>
-                                    <td><?= $pedido['fecha'] ?></td>
+                                    <td><?= $producto ?></td>
+                                    <td><?= number_format($pedido['cantidad'], 2, ',', '.') ?></td>
+                                    <td><?= $unidad ?></td>
+                                    <td><?= $estado ?></td>
+                                    <td><?= $fecha ?></td>
                                 </tr>
                             <?php endforeach; ?>
                         </tbody>

--- a/views/cliente/productos.php
+++ b/views/cliente/productos.php
@@ -20,12 +20,27 @@
             <?php foreach ($productos as $producto): ?>
                 <div class="col-12 col-md-6 col-xl-4">
                     <div class="portal-card h-100">
-                        <img src="<?= $producto['imagen'] ?>" class="img-fluid rounded-4 mb-3" alt="<?= $producto['nombre'] ?>">
+                        <?php
+                            $unidadVentaClave = $producto['unidad_venta'] === 'rollo' ? 'rollo' : 'metro';
+                            $unidadVenta = $unidadVentaClave === 'rollo' ? 'Rollo completo' : 'Metro lineal';
+                            $nombreProducto = htmlspecialchars($producto['nombre'], ENT_QUOTES, 'UTF-8');
+                            $descripcionProducto = htmlspecialchars($producto['descripcion'], ENT_QUOTES, 'UTF-8');
+                            $colorProducto = htmlspecialchars($producto['color'], ENT_QUOTES, 'UTF-8');
+                            $imagenProducto = htmlspecialchars($producto['imagen'], ENT_QUOTES, 'UTF-8');
+                        ?>
+                        <img src="<?= $imagenProducto ?>" class="img-fluid rounded-4 mb-3" alt="<?= $nombreProducto ?>">
                         <div class="d-flex justify-content-between align-items-start">
-                            <h5 class="fw-semibold mb-1"><?= $producto['nombre'] ?></h5>
-                            <span class="badge bg-light text-primary fw-semibold">$<?= number_format($producto['precio'], 2) ?></span>
+                            <h5 class="fw-semibold mb-1"><?= $nombreProducto ?></h5>
+                            <div class="text-end">
+                                <span class="badge bg-light text-primary fw-semibold d-block">Bs <?= number_format($producto['precio'], 2, ',', '.') ?></span>
+                                <small class="text-muted">por <?= strtolower($unidadVenta) ?></small>
+                            </div>
                         </div>
-                        <p class="text-muted mb-4"><?= $producto['descripcion'] ?></p>
+                        <p class="text-muted mb-3"><?= $descripcionProducto ?></p>
+                        <ul class="list-unstyled small text-muted mb-4">
+                            <li><strong>Color:</strong> <?= $colorProducto ?></li>
+                            <li><strong>Unidad de venta:</strong> <?= $unidadVenta ?></li>
+                        </ul>
                         <a href="agregar_pedido.php?id=<?= $producto['id'] ?>" class="btn btn-primary w-100">Reservar ahora</a>
                     </div>
                 </div>

--- a/views/public/productos.php
+++ b/views/public/productos.php
@@ -19,13 +19,28 @@
             <div class="product-grid">
                 <?php foreach ($productos as $producto): ?>
                     <article class="product-card">
-                        <img src="<?= $producto['imagen'] ?>" alt="<?= $producto['nombre'] ?>">
+                        <?php
+                            $unidadVentaClave = $producto['unidad_venta'] === 'rollo' ? 'rollo' : 'metro';
+                            $unidadVenta = $unidadVentaClave === 'rollo' ? 'Rollo completo' : 'Metro lineal';
+                            $nombreProducto = htmlspecialchars($producto['nombre'], ENT_QUOTES, 'UTF-8');
+                            $descripcionProducto = htmlspecialchars($producto['descripcion'], ENT_QUOTES, 'UTF-8');
+                            $colorProducto = htmlspecialchars($producto['color'], ENT_QUOTES, 'UTF-8');
+                            $imagenProducto = htmlspecialchars($producto['imagen'], ENT_QUOTES, 'UTF-8');
+                        ?>
+                        <img src="<?= $imagenProducto ?>" alt="<?= $nombreProducto ?>">
                         <div class="card-body">
                             <div class="d-flex justify-content-between align-items-start mb-3">
-                                <h5 class="card-title mb-0"><?= $producto['nombre'] ?></h5>
-                                <span class="product-price">$<?= number_format($producto['precio'], 2) ?></span>
+                                <h5 class="card-title mb-0"><?= $nombreProducto ?></h5>
+                                <div class="text-end">
+                                    <span class="product-price d-block">Bs <?= number_format($producto['precio'], 2, ',', '.') ?></span>
+                                    <small class="text-muted">por <?= strtolower($unidadVenta) ?></small>
+                                </div>
                             </div>
-                            <p class="card-text mb-4"><?= $producto['descripcion'] ?></p>
+                            <p class="card-text mb-3"><?= $descripcionProducto ?></p>
+                            <ul class="product-details list-unstyled small mb-4">
+                                <li><strong>Color:</strong> <?= $colorProducto ?></li>
+                                <li><strong>Unidad de venta:</strong> <?= $unidadVenta ?></li>
+                            </ul>
                             <div class="d-flex justify-content-between align-items-center">
                                 <span class="badge-soft">Stock garantizado</span>
                                 <a href="/camila-textil/views/cliente/productos.php" class="btn btn-primary">Reservar</a>


### PR DESCRIPTION
## Summary
- add textile-specific color and unit fields to the schema and adjust pedidos/inventario quantities to decimal values in bolivianos
- update seed data plus product controller and model logic to persist the new textile attributes
- unify public, client, and admin product/inventory/pedido views around consistent textile details and Bs pricing

## Testing
- php -l controllers/productos.php
- php -l models/producto.php
- php -l models/inventario.php
- php -l views/public/productos.php

------
https://chatgpt.com/codex/tasks/task_e_68e7bdf80148832590fb8385402a3942